### PR TITLE
Reduce pkg-config version requirement

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,8 @@ AC_ARG_WITH([globus],
 		[Enable Globus GSI authentication support]),
 	[gsi_path="$withval"])
 
+PKG_PROG_PKG_CONFIG([0.22])
+
 if test "x$gsi_path" != "xno" ; then
 	# Globus GSSAPI configuration
 	AC_MSG_CHECKING(for Globus GSI)
@@ -52,10 +54,9 @@ if test "x$gsi_path" != "xno" ; then
 		GSSAPI="GSI"
 	fi
 
-	PKG_PROG_PKG_CONFIG([0.28])
 
 	# include explicit openssl dependency to get consistent LIBS
-	PKG_CHECK_MODULES([GLOBUS_PKG], [globus-gss-assist >= 2, globus-gssapi-gsi, globus-usage >= 1, globus-common, openssl])
+	PKG_CHECK_MODULES([GLOBUS_PKG], [globus-gss-assist >= 2, globus-gssapi-gsi, globus-usage >= 1, globus-common])
 	PKG_CHECK_MODULES([OPENSSL], [openssl])
 
         CFLAGS="$CFLAGS $OPENSSL_CFLAGS"


### PR DESCRIPTION
This patch changes the required pkg-config version from 0.28 to 0.22. The versions of pkg-config in the OSes we support for GT are all 0.22 or larger.

I don't think this negatively affects builds except for OS X builds which attempt to build a fat binary (0.28 fixes a bug with pkg-config losing multiple -arch options). On the GT build system, our OS X machine has the newer version of pkg-config installed.